### PR TITLE
feat(build): add build instructions for nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746328495,
+        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Meow!";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    system = "x86_64-linux";
+  in {
+    packages.x86_64-linux.meow = nixpkgs.legacyPackages.${system}.rustPlatform.buildRustPackage {
+      version = "1.0.1";
+      name = "meow";
+
+      src = ./.;
+      cargoLock.lockFile = ./Cargo.lock;
+    };
+
+    packages.x86_64-linux.default = self.packages.x86_64-linux.meow;
+  };
+}


### PR DESCRIPTION
Hi, I enjoy the idea of this and would love neovim as a previewer especially in a non-interactive environment.
Anyways in order to test this, I needed a version that can run on NixOS, which default Linux binaries do not.
So I packaged it.

Also, this relies on nixos-unstable as the nixpkgs source because NixOS-24.11 does not yet include Rust Edition2024.
